### PR TITLE
[Core] Tying wandb CLI Args in Capacity Search

### DIFF
--- a/metron/capacity_search/capacity_search.py
+++ b/metron/capacity_search/capacity_search.py
@@ -241,9 +241,10 @@ class CapacitySearch:
             ),
             qps=qps,
             tbt_deadline=self.args.tbt_slo,
-            wandb_project="Metron",
-            wandb_group="gatech-sysml",
-            wandb_run_name=f"qps_{qps}_model_{self.job_config.model_config.name}_ttftslack_{self.args.ttft_slack_slo}_tbt_{self.args.tbt_slo}_tpot_{self.args.tpot_slo}_ttft_{self.args.ttft_slo}_trace_{self.job_config.request_generator_config.trace_file_name}",
+            wandb_project=self.args.wandb_project,
+            wandb_group=self.args.wandb_group,
+            wandb_run_name=f"qps_{qps}_model_{self.job_config.model_config.name}_engine_{self.job_config.server_config.openai_server_engine}",
+            should_write_metrics=self.args.should_write_metrics_to_wandb,
         )
 
         run_dir = benchmark_config.get_run_dir()
@@ -347,7 +348,7 @@ class CapacitySearch:
             f"Best Run ID: {best_run_id}",
         )
 
-        if self.args.wandb_project is not None:
+        if self.args.wandb_project is not None and self.args.enable_wandb_sweep:
             best_run = wandb.Api().run(f"{self.args.wandb_project}/{best_run_id}")
             best_run.tags.append("BEST_CONFIG")
             best_run.update()

--- a/metron/capacity_search/config/config.py
+++ b/metron/capacity_search/config/config.py
@@ -373,8 +373,11 @@ class BenchmarkConfig:
         args = []
         for key, value in config_dict.items():
             if value is not None:
-                if isinstance(value, bool) and value:
-                    args.append(f"--{key}")
+                if isinstance(value, bool):
+                    if value:
+                        args.append(f"--{key}")
+                    else:
+                        args.append(f"--no-{key}")
                 else:
                     args.append(f"--{key} {value}")
         return " ".join(args)

--- a/metron/capacity_search/config/config.py
+++ b/metron/capacity_search/config/config.py
@@ -372,10 +372,11 @@ class BenchmarkConfig:
         config_dict = self.to_config_dict()
         args = []
         for key, value in config_dict.items():
-            if isinstance(value, bool) and value:
-                args.append(f"--{key}")
-            elif value is not None:
-                args.append(f"--{key} {value}")
+            if value is not None:
+                if isinstance(value, bool) and value:
+                    args.append(f"--{key}")
+                else:
+                    args.append(f"--{key} {value}")
         return " ".join(args)
 
     def get_run_id(self):

--- a/metron/capacity_search/config/config.py
+++ b/metron/capacity_search/config/config.py
@@ -352,6 +352,7 @@ class BenchmarkConfig:
     wandb_group: Optional[str] = None
     wandb_project: Optional[str] = None
     wandb_run_name: Optional[str] = None
+    should_write_metrics: Optional[bool] = True
 
     def to_config_dict(self):
         return {
@@ -364,13 +365,16 @@ class BenchmarkConfig:
             "wandb-group": self.wandb_group,
             "wandb-project": self.wandb_project,
             "wandb-run-name": self.wandb_run_name,
+            "should-write-metrics": self.should_write_metrics,
         }
 
     def to_args(self):
         config_dict = self.to_config_dict()
         args = []
         for key, value in config_dict.items():
-            if value is not None:
+            if isinstance(value, bool) and value:
+                args.append(f"--{key}")
+            else:
                 args.append(f"--{key} {value}")
         return " ".join(args)
 

--- a/metron/capacity_search/config/config.py
+++ b/metron/capacity_search/config/config.py
@@ -374,7 +374,7 @@ class BenchmarkConfig:
         for key, value in config_dict.items():
             if isinstance(value, bool) and value:
                 args.append(f"--{key}")
-            else:
+            elif value is not None:
                 args.append(f"--{key} {value}")
         return " ".join(args)
 

--- a/metron/capacity_search/main.py
+++ b/metron/capacity_search/main.py
@@ -50,10 +50,20 @@ def get_args():
     )
     parser.add_argument("--wandb-project", type=str, default=None)
     parser.add_argument("--wandb-group", type=str, default=None)
-    parser.add_argument("--should-write-metrics-to-wandb", type=bool, action=argparse.BooleanOptionalAction, default=False)
+    parser.add_argument(
+        "--should-write-metrics-to-wandb",
+        type=bool,
+        action=argparse.BooleanOptionalAction,
+        default=False,
+    )
     parser.add_argument("--wandb-sweep-name", type=str, default=None)
     parser.add_argument("--wandb-sweep-id", type=str, default=None)
-    parser.add_argument("--enable-wandb-sweep", type=bool, action=argparse.BooleanOptionalAction, default=False)
+    parser.add_argument(
+        "--enable-wandb-sweep",
+        type=bool,
+        action=argparse.BooleanOptionalAction,
+        default=False,
+    )
 
     args = parser.parse_args()
 

--- a/metron/capacity_search/main.py
+++ b/metron/capacity_search/main.py
@@ -49,12 +49,15 @@ def get_args():
         "--debug", action="store_true", help="Print debug logs and commands"
     )
     parser.add_argument("--wandb-project", type=str, default=None)
+    parser.add_argument("--wandb-group", type=str, default=None)
+    parser.add_argument("--should-write-metrics-to-wandb", type=bool, action=argparse.BooleanOptionalAction, default=False)
     parser.add_argument("--wandb-sweep-name", type=str, default=None)
     parser.add_argument("--wandb-sweep-id", type=str, default=None)
+    parser.add_argument("--enable-wandb-sweep", type=bool, action=argparse.BooleanOptionalAction, default=False)
 
     args = parser.parse_args()
 
-    if args.wandb_project:
+    if args.wandb_project and args.enable_wandb_sweep:
         assert (
             args.wandb_sweep_name or args.wandb_sweep_id
         ), "wandb-sweep-name/id is required with wandb-project"
@@ -80,7 +83,7 @@ if __name__ == "__main__":
     # store the config and args
     json.dump(config, open(f"{args.output_dir}/config.json", "w"))
 
-    if args.wandb_project and not args.wandb_sweep_id:
+    if args.wandb_project and args.enable_wandb_sweep and not args.wandb_sweep_id:
         config["name"] = args.wandb_sweep_name
         config["method"] = "custom"
 

--- a/metron/run_benchmark.py
+++ b/metron/run_benchmark.py
@@ -435,6 +435,7 @@ def parse_args():
         "--should-use-given-dir",  # added to prevent the creation of a new directories for the capacity search
         type=bool,
         default=True,
+        action=argparse.BooleanOptionalAction,
         help=(
             "Whether to add directly use --output-dir directory or create new directories for the results. (default: %(default)s)"
         ),


### PR DESCRIPTION
Issue: wandb config was hardcoded inside capacity search code.

Changes:
1. Added CLI args to specify `wandb-group`, `should-write-metrics-to-wandb` and `enable-wandb-sweep`.
2. Updated config.py/BenchmarkConfig object to take in `should-write-metrics-to-wandb` arg
3. Updated capacity search code to take in wandb related args
4. Made boolean arg of `should-use-given-dir` of BooleanOptionalAction action type.
5. Updated `to_args()` logic in `BenchmarkConfig` class to pass handle boolean parameters.
